### PR TITLE
Preview themes in extension window

### DIFF
--- a/crates/theme_selector/src/theme_preview.rs
+++ b/crates/theme_selector/src/theme_preview.rs
@@ -1,0 +1,141 @@
+use editor::{Editor, EditorElement, EditorStyle};
+use gpui::{
+    App, Context, Entity, Render, Styled, TextStyle, Window, prelude::*,
+};
+use theme::{Theme, ThemeSettings};
+use ui::prelude::*;
+
+/// A component that renders a preview of a theme showing sample code and UI elements
+pub struct ThemePreview {
+    editor: Entity<Editor>,
+    theme: Arc<Theme>,
+}
+
+impl ThemePreview {
+    pub fn new(theme: Arc<Theme>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            
+            // Set sample code content
+            let sample_code = r#"fn main() {
+    let message = "Hello, World!";
+    println!("{}", message);
+    
+    // This is a comment
+    let numbers = vec![1, 2, 3, 4, 5];
+    
+    for num in numbers {
+        if num % 2 == 0 {
+            println!("Even: {}", num);
+        } else {
+            println!("Odd: {}", num);
+        }
+    }
+}"#;
+            
+            editor.set_text(sample_code, window, cx);
+            editor.set_read_only(true, cx);
+            editor
+        });
+
+        Self { editor, theme }
+    }
+}
+
+impl Render for ThemePreview {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let settings = ThemeSettings::get_global(cx);
+        let text_style = TextStyle {
+            color: self.theme.colors().text,
+            font_family: settings.ui_font.family.clone(),
+            font_features: settings.ui_font.features.clone(),
+            font_fallbacks: settings.ui_font.fallbacks.clone(),
+            font_size: rems(0.6).into(),
+            font_weight: settings.ui_font.weight,
+            line_height: relative(1.3),
+            ..Default::default()
+        };
+
+        let editor_style = EditorStyle {
+            background: self.theme.colors().editor_background,
+            local_player: self.theme.players().local(),
+            text: text_style,
+            ..Default::default()
+        };
+
+        v_flex()
+            .w(rems(14.))
+            .h(rems(10.))
+            .bg(self.theme.colors().background)
+            .border_1()
+            .border_color(self.theme.colors().border)
+            .rounded_md()
+            .overflow_hidden()
+            .child(
+                // Header bar
+                h_flex()
+                    .w_full()
+                    .h_6()
+                    .bg(self.theme.colors().surface_background)
+                    .border_b_1()
+                    .border_color(self.theme.colors().border_variant)
+                    .px_2()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        div()
+                            .w_2()
+                            .h_2()
+                            .bg(self.theme.colors().error)
+                            .rounded_full()
+                    )
+                    .child(
+                        div()
+                            .w_2()
+                            .h_2()
+                            .bg(self.theme.colors().warning)
+                            .rounded_full()
+                    )
+                    .child(
+                        div()
+                            .w_2()
+                            .h_2()
+                            .bg(self.theme.colors().success)
+                            .rounded_full()
+                    )
+                    .child(
+                        Label::new("theme-preview.rs")
+                            .size(LabelSize::XSmall)
+                            .color(self.theme.colors().text_muted)
+                    )
+            )
+            .child(
+                // Editor content
+                EditorElement::new(&self.editor, editor_style)
+                    .flex_1()
+                    .p_2()
+            )
+            .child(
+                // Status bar
+                h_flex()
+                    .w_full()
+                    .h_4()
+                    .bg(self.theme.colors().surface_background)
+                    .border_t_1()
+                    .border_color(self.theme.colors().border_variant)
+                    .px_2()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        Label::new("Rust")
+                            .size(LabelSize::XSmall)
+                            .color(self.theme.colors().text_muted)
+                    )
+                    .child(
+                        Label::new("Ln 1, Col 1")
+                            .size(LabelSize::XSmall)
+                            .color(self.theme.colors().text_muted)
+                    )
+            )
+    }
+}

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -1,4 +1,5 @@
 mod icon_theme_selector;
+mod theme_preview;
 
 use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
@@ -16,6 +17,7 @@ use workspace::{ModalView, Workspace, ui::HighlightedLabel, with_active_or_new_w
 use zed_actions::{ExtensionCategoryFilter, Extensions};
 
 use crate::icon_theme_selector::{IconThemeSelector, IconThemeSelectorDelegate};
+use crate::theme_preview::ThemePreview;
 
 actions!(
     theme_selector,
@@ -94,7 +96,7 @@ impl Render for ThemeSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .key_context("ThemeSelector")
-            .w(rems(34.))
+            .w(rems(50.))
             .child(self.picker.clone())
     }
 }
@@ -342,20 +344,39 @@ impl PickerDelegate for ThemeSelectorDelegate {
         &self,
         ix: usize,
         selected: bool,
-        _window: &mut Window,
-        _cx: &mut Context<Picker<Self>>,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let theme_match = &self.matches[ix];
+
+        // Get the theme for preview
+        let registry = ThemeRegistry::global(cx);
+        let theme_preview = registry.get(&theme_match.string).ok().map(|theme| {
+            cx.new(|cx| ThemePreview::new(theme, window, cx))
+        });
 
         Some(
             ListItem::new(ix)
                 .inset(true)
-                .spacing(ListItemSpacing::Sparse)
+                .spacing(ListItemSpacing::Dense)
                 .toggle_state(selected)
-                .child(HighlightedLabel::new(
-                    theme_match.string.clone(),
-                    theme_match.positions.clone(),
-                )),
+                .child(
+                    h_flex()
+                        .gap_4()
+                        .items_start()
+                        .py_2()
+                        .child(
+                            v_flex()
+                                .flex_1()
+                                .child(HighlightedLabel::new(
+                                    theme_match.string.clone(),
+                                    theme_match.positions.clone(),
+                                ))
+                        )
+                        .when_some(theme_preview, |this, preview| {
+                            this.child(preview)
+                        })
+                ),
         )
     }
 


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Improved theme selection by adding a live preview of each theme in the theme selector, showing a mini editor with sample code and UI elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-9390f535-2fc8-45ef-99f2-29d4d0dad6c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9390f535-2fc8-45ef-99f2-29d4d0dad6c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

